### PR TITLE
Add support for 'format' plugin option.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,4 @@
 {
-    "presets": [
-      ["babel-preset-gatsby-package"]
-    ]
-  }
+  "presets": [["babel-preset-gatsby-package"]],
+  "plugins": ["@babel/plugin-proposal-nullish-coalescing-operator"]
+}

--- a/README.md
+++ b/README.md
@@ -129,6 +129,23 @@ module.exports = {
 
 The root of the git repository. Will use current directory if not provided.
 
+**`format`** [object][optional]
+
+The plugin will add fields to the `File` node based on the keys of the format object.
+The values represent which `git log` [format string] to place in each field.
+
+[format string]: https://git-scm.com/docs/pretty-formats#Documentation/pretty-formats.txt-emHem
+
+If not provided, defaults to:
+
+```javascript
+{
+  gitLogLatestDate: `%ai`,
+  gitLogLatestAuthorName: `%an`,
+  gitLogLatestAuthorEmail: "%ae",
+}
+```
+
 ## Example
 
 **Note:** the execution order is first `ìnclude`, then `ignore`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -376,6 +376,24 @@
         "@babel/plugin-syntax-json-strings": "^7.2.0"
       }
     },
+    "@babel/plugin-proposal-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-TS9MlfzXpXKt6YYomudb/KU7nQI6/xnapG6in1uZxoxDghuSMZsPb6D2fyUwNYSAp4l1iR7QtFOjkqcRYcUsfw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
+          "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
+          "dev": true
+        }
+      }
+    },
     "@babel/plugin-proposal-object-rest-spread": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.6.2.tgz",
@@ -459,6 +477,23 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
+          "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
+          "dev": true
+        }
       }
     },
     "@babel/plugin-syntax-object-rest-spread": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@babel/cli": "7.7.0",
     "@babel/core": "7.7.2",
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
     "babel-preset-gatsby-package": "0.2.9",
     "cross-env": "5.2.1",
     "jest": "24.9.0"

--- a/src/__tests__/gatsby_node.js
+++ b/src/__tests__/gatsby_node.js
@@ -5,6 +5,7 @@ const git = require("simple-git/promise");
 const { onCreateNode } = require(`../gatsby-node`);
 
 const tmpDir = `./tmp-test/`;
+const iso8601pattern = /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z)/;
 
 let createNodeField;
 let actions;
@@ -117,5 +118,31 @@ describe(`Processing File nodes matching filter regex`, () => {
       dir: dummyRepoPath
     });
     expect(createNodeField).not.toHaveBeenCalled();
+  });
+
+  it("should use log format options if specified", async () => {
+    node.absolutePath = `${dummyRepoPath}/README.md`;
+    node.dir = dummyRepoPath;
+    await onCreateNode(createNodeSpec, {
+      include: /md/,
+      dir: dummyRepoPath,
+      format: {
+        gitLogLatestCommitDate: `%cI`,
+        gitLogLatestSubject: `%s`
+      }
+    });
+    expect(createNodeField).toHaveBeenCalledTimes(2);
+    expect(createNodeField).toHaveBeenCalledWith(
+      expect.objectContaining({
+        node,
+        name: `gitLogLatestCommitDate`,
+        value: expect.stringMatching(iso8601pattern)
+      })
+    );
+    expect(createNodeField).toHaveBeenCalledWith({
+      node,
+      name: `gitLogLatestSubject`,
+      value: `Add README`
+    });
   });
 });

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,21 +1,17 @@
 const git = require(`simple-git/promise`);
 
-async function getLogWithRetry(gitRepo, node, retry = 2) {
+async function getLogWithRetry(gitRepo, node, format, retry = 2) {
   // Need retry, see https://github.com/steveukx/git-js/issues/302
   // Check again after v2 is released?
 
   const logOptions = {
     file: node.absolutePath,
     n: 1,
-    format: {
-      date: `%ai`,
-      authorName: `%an`,
-      authorEmail: "%ae"
-    }
+    format,
   };
   const log = await gitRepo.log(logOptions);
   if (!log.latest && retry > 0) {
-    return getLogWithRetry(gitRepo, node, retry - 1);
+    return getLogWithRetry(gitRepo, node, format, retry - 1);
   }
 
   return log;
@@ -36,28 +32,26 @@ async function onCreateNode({ node, actions }, pluginOptions) {
     return;
   }
 
+  const format = pluginOptions.format ?? {
+    gitLogLatestDate: `%ai`,
+    gitLogLatestAuthorName: `%an`,
+    gitLogLatestAuthorEmail: "%ae",
+  };
+
   const gitRepo = git(pluginOptions.dir);
-  const log = await getLogWithRetry(gitRepo, node);
+  const log = await getLogWithRetry(gitRepo, node, format);
 
   if (!log.latest) {
     return;
   }
 
-  createNodeField({
-    node,
-    name: `gitLogLatestAuthorName`,
-    value: log.latest.authorName
-  });
-  createNodeField({
-    node,
-    name: `gitLogLatestAuthorEmail`,
-    value: log.latest.authorEmail
-  });
-  createNodeField({
-    node,
-    name: `gitLogLatestDate`,
-    value: log.latest.date
-  });
+  for (const name in format) {
+    createNodeField({
+      node,
+      name,
+      value: log.latest[name],
+    });
+  }
 }
 
 exports.onCreateNode = onCreateNode;


### PR DESCRIPTION
This commit adds support for a user-supplied set of fields to get
`git log` information for instead of a fixed set.  The primary
motivation for this change was to support getting "commit date" instead
of author date, but it seemed better to create a more flexible solution
rather than focusing on a single new field.

For more details see the updated README.md file.